### PR TITLE
Fix decoder

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -102,12 +102,13 @@ func main() {
 			// Probably it is because buffer reset retains underlying storage
 			var msgBuffer bytes.Buffer
 			var bodyBuffer bytes.Buffer
-			msgDecoder := gob.NewDecoder(&msgBuffer)
-			bodyDecoder := gob.NewDecoder(&bodyBuffer)
 
 			for msg := range msgs {
 				msgBuffer.Reset()
 				bodyBuffer.Reset()
+
+				msgDecoder := gob.NewDecoder(&msgBuffer)
+				bodyDecoder := gob.NewDecoder(&bodyBuffer)
 
 				if _, err := msgBuffer.Write(msg.Body); err != nil {
 					ErrorLogger.Print(err)


### PR DESCRIPTION
If you are trying to add multiple items you will receive error message:

```bash
// client:
for i in $(seq 0 1000); do bin/client --action add -key key${i} -value val-${i}; done

// server log:
ERROR: 2022/02/11 10:39:38 main.go:119: extra data in buffer
```

This happens because gob encoder was designed to encode one object to buffer. Somewhy I was not faced this problem before, maybe I changed a bit code and not tested again. But anyway this should work:


```bash
// client:
for i in $(seq 0 1000); do bin/client --action add -key key${i} -value val-${i}; done

// server log:
DEBUG: 2022/02/11 10:40:06 main.go:135: Adding item, key: key0 value: val-0
DEBUG: 2022/02/11 10:40:06 main.go:135: Adding item, key: key1 value: val-1
DEBUG: 2022/02/11 10:40:06 main.go:135: Adding item, key: key2 value: val-2
// ...
```